### PR TITLE
Improve alignment of popover controls on tablet

### DIFF
--- a/lib/src/popover_position_render_object.dart
+++ b/lib/src/popover_position_render_object.dart
@@ -103,7 +103,13 @@ class PopoverPositionRenderObject extends RenderShiftedBox {
     } else if (attachRect!.left < size.width / 2) {
       offset = arrowHeight!;
     } else {
-      offset = Utils().screenWidth - arrowHeight! - size.width;
+
+      // In this case the popover was shifted relative to the center of the widget
+      // We need to leave it in the center
+
+      // offset = Utils().screenWidth - arrowHeight! - size.width;
+
+      offset = attachRect!.left + attachRect!.width / 2 - size.width / 2;
     }
     return offset;
   }


### PR DESCRIPTION
Although editors show as a popover:

Arrow indicator many times is shown disconnected from the popover, as shown in image

popover box not centered in screen

![image](https://user-images.githubusercontent.com/50525087/123287328-557ab000-d517-11eb-8157-620ddecf6c0c.png)